### PR TITLE
Update link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pretendo Network Installer/Patcher (for the WiiU)
 
-[![N|Solid](https://camo.githubusercontent.com/b98196c2347796d66fa669e8510749665ec80ba0/68747470733a2f2f692e696d6775722e636f6d2f5839346237574b2e706e67)](https://pretendo.cc)
+[![N|Solid](https://camo.githubusercontent.com/b98196c2347796d66fa669e8510749665ec80ba0/68747470733a2f2f692e696d6775722e636f6d2f5839346237574b2e706e67)](https://pretendo.network)
 
 This is the official Pretendo Installer for the Wii U. It will patch your console's IOSU (ARM microkernel) temporarily (goes away after a reboot) to modify Nintendo URLs to Pretendo URLs.
 


### PR DESCRIPTION
The link before was "pretendo.cc" which is for the servers. The website is pretendo.network