### PR TITLE
Fixed the makefile to work with the more recent versions of wut

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ CXXFLAGS	:= $(CFLAGS)
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-g $(ARCH) $(RPXSPECS) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:=  -lgui -lfreetype -lgd -lpng -ljpeg -lz -lmad -lvorbisidec -logg -lbz2 -lwut 
+LIBS	:=  - -lz -lwut 
 
 #-------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ CXXFLAGS	:= $(CFLAGS)
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-g $(ARCH) $(RPXSPECS) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:=  - -lz -lwut 
+LIBS	:=  -lz -lwut 
 
 #-------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level


### PR DESCRIPTION
wut has combined all of those libraries into -lwut. including the others in the makefile will cause linker errors when compiling.