### PR TITLE
Removed inaccuracy from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This is the official Pretendo Installer for the Wii U. It will patch your consol
 - **devkitPro** (PPC only, ARM code is already built)
 
 You need to set **devkitPro\msys\bin** into your PATH
-You also need the latest wut version from the github, the one hosted (updated from pacman commands) isn't supported
   
 # Credits
 - Pretendo Network team


### PR DESCRIPTION
The readme currently states that the version of wut distributed using `dkp-pacman` is not compatible with the code and you need to use the version from the github instead. This is incorrect. The current version of  wut from `dkp-pacman` works fine without issues.